### PR TITLE
tests, some speed improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,7 @@ vignettes/*.pdf
 
 # R Environment Variables
 .Renviron
+
+.Rbuildignore
+tests/.DS_Store
+.DS_Store

--- a/R/ars.R
+++ b/R/ars.R
@@ -24,7 +24,7 @@ ars <- function(density, n_samples, k = 5) {
     is_concave == TRUE,
     msg = "Density is not log-concave for given set of points."
   )
-  samples <- vector()
+  samples <- rep(0, n_samples)
   
   if (density(-Inf) == 0) {
     # todo optimize how x1 is selected
@@ -74,7 +74,8 @@ ars <- function(density, n_samples, k = 5) {
           (x - abscissae[j]) * log(density(abscissae[j + 1]))) / (abscissae[j + 1] - abscissae[j]))
   }
   
-  while (length(samples) < n_samples) {
+  num_sampled <- 1
+  while (num_sampled <= n_samples) {
     sample <- sample_from_hull(normalized_upper_hull)
     w <- runif(1)
     
@@ -85,7 +86,8 @@ ars <- function(density, n_samples, k = 5) {
     
     if (w <= exp(lower_bound - upper_bound)) {
       # accept the sample
-      samples <- sort(c(samples, sample))
+      samples[num_sampled] <- sample
+      num_sampled <- num_sampled + 1
     } else {
       # update tangents and points, check concavity conditions
       # are still met
@@ -101,7 +103,8 @@ ars <- function(density, n_samples, k = 5) {
       
       if (w <= exp(log_density - upper_bound)) {
         # accept the sample only if this condition is met
-        samples <- sort(c(samples, sample))
+        samples[num_sampled] <- sample
+        num_sampled <- num_sampled + 1
       }
     }
   }

--- a/tests/testthat/test_ars.R
+++ b/tests/testthat/test_ars.R
@@ -46,3 +46,16 @@ test_that("test cdf", {
   expect_equal(result,expected, tolerance=tol)
   
 })
+
+test_that("test calc tangents", {
+  # d/dx of log(std normal) = -x
+  abscis = c(-1,0)
+  
+  #tangent to 0 is  y = -1/2 log(2 π)
+  #and tangent line to -1 is  = x + 1 + 1/2 (-1 - log(2 π)) 
+  # and they intersect at x=-.5
+  expected = -.5
+  result = calculate_tangents(abscis, dnorm)
+  expect_equal(result,expected, tolerance=tol)
+  
+})


### PR DESCRIPTION
we're having issues with NaNs in our tangent vector. this is because some very large points are being sampled from the hull (like an x value of 10k from a standard normal distribution) --> density is represented as 0 --> the derivative function evaluates 0/0 and returns NaN.

Not sure our desired fix for this. I thought about having derivative return 0 when the density is 0, and this works in the normal case, but I'm not sure it works for all distributions...
Ideally, we should investigate why such large values are being sampled from the hull which results in the extremely large abscissa being added. 